### PR TITLE
Fix Package.swift dependencies versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
         .library(name: "FuturaeKit", targets: ["FuturaeKit", "FuturaeKitUmbrella"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Futurae-Technologies/ios-sdk/releases/download/v2.4.2/FuturaeKit-v2.4.2.xcframework.zip", .upToNextMajor(from: "0.14.1")),
-        .package(url: "https://github.com/Futurae-Technologies/ios-sdk/releases/download/v2.4.2/FuturaeKit-v2.4.2.xcframework.zip", .upToNextMajor(from: "6.6.0")),
+        .package(url: "https://github.com/stephencelis/SQLite.swift.git", .upToNextMajor(from: "0.14.1")),
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.6.0")),
     ],
     targets: [
         .binaryTarget(


### PR DESCRIPTION
Hello Futurae team,

Could you please fix your Package.swift file to enable installing your SDK via SPM? It seems that it hasn't been working since version 3.2.2 of your SDK.

Thank you!